### PR TITLE
Blend speed up

### DIFF
--- a/pypoi/poissonblending.py
+++ b/pypoi/poissonblending.py
@@ -75,7 +75,7 @@ def blend(img_target, img_source, img_mask, offset=(0, 0)):
                     b[index] = t[index]
 
         # solve Ax = b
-        x = pyamg.solve(A, b, verb=False, tol=1e-10)
+        x = scipy.sparse.linalg.spsolve(A, b)
 
         # assign x to target image
         x = np.reshape(x, region_size)

--- a/pypoi/poissonblending.py
+++ b/pypoi/poissonblending.py
@@ -79,8 +79,7 @@ def blend(img_target, img_source, img_mask, offset=(0, 0)):
 
         # assign x to target image
         x = np.reshape(x, region_size)
-        x[x > 255] = 255
-        x[x < 0] = 0
+        x = np.clip(x, 0, 255)
         x = np.array(x, img_target.dtype)
         img_target[region_target[0]:region_target[2], region_target[1]:region_target[3], num_layer] = x
 

--- a/pypoi/poissonblending.py
+++ b/pypoi/poissonblending.py
@@ -58,6 +58,10 @@ def blend(img_target, img_source, img_mask, offset=(0, 0)):
     # create poisson matrix for b
     P = pyamg.gallery.poisson(img_mask.shape)
 
+    # get positions in mask that should be taken from the target
+    inverted_img_mask = np.invert(img_mask.astype(np.bool)).flatten()
+    positions_from_target = np.where(inverted_img_mask)[0]
+
     # for each layer (ex. RGB)
     for num_layer in range(img_target.shape[2]):
         # get subimages
@@ -68,11 +72,7 @@ def blend(img_target, img_source, img_mask, offset=(0, 0)):
 
         # create b
         b = P * s
-        for y in range(region_size[0]):
-            for x in range(region_size[1]):
-                if not img_mask[y, x]:
-                    index = x + y * region_size[1]
-                    b[index] = t[index]
+        b[positions_from_target] = t[positions_from_target]
 
         # solve Ax = b
         x = scipy.sparse.linalg.spsolve(A, b)


### PR DESCRIPTION
this commit tries to address issue #12
I've reduced loop iterations while creating the coefficient matrix and b vector (by Using NumPy/Scipy operations).
This reduced the runtime on my machine from 4.5~ seconds on average to 3.6~ seconds on average. 

Furthermore I've changed the function which solves the linear problem from pyamg.solve to Scipy.sparse.linalg.spsolve.

All changes together reduces runtime on average from 4.5~ to 0.5~ seconds. 

All tests were done with the test() function in file poissonblending.py, time measure without saving the image. 
